### PR TITLE
fix: remove automatic security issue creation in CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,8 +22,6 @@ jobs:
   rust-audit:
     name: Rust Dependency Audit
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,25 +49,10 @@ jobs:
         working-directory: ./src-tauri
         run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0001 --ignore RUSTSEC-2026-0002
 
-      - name: Report vulnerabilities
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Security Vulnerability Detected',
-              body: 'A security vulnerability was detected in the dependencies. Please review the CI logs.',
-              labels: ['security', 'bug']
-            })
-
   # npm/pnpm 安全审计
   node-audit:
     name: Node.js Dependency Audit
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -102,19 +85,6 @@ jobs:
       - name: Run security audit
         working-directory: ./src
         run: pnpm audit --prod --level high
-
-      - name: Report vulnerabilities
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Node.js Security Vulnerability Detected',
-              body: 'A security vulnerability was detected in the npm dependencies. Please review the CI logs.',
-              labels: ['security', 'bug']
-              })
 
   # 依赖漏洞检查报告
   dependency-review:


### PR DESCRIPTION
## Summary

Removed automatic security issue creation in CI to prevent issue spam when known/acceptable vulnerabilities are detected.

## Changes

1. **Removed `Report vulnerabilities` step from rust-audit job** - Cargo audit failures are now only reported in CI logs
2. **Removed `Report vulnerabilities` step from node-audit job** - pnpm audit failures are now only reported in CI logs  
3. **Removed `permissions: issues: write`** - No longer needed since we're not creating issues

## Behavior Before vs After

| Before | After |
|--------|-------|
| cargo-audit fails → Creates issue "Security Vulnerability Detected" | cargo-audit fails → CI fails, check logs for details |
| pnpm audit fails → Creates issue "Node.js Security Vulnerability Detected" | pnpm audit fails → CI fails, check logs for details |

Security scans still run and will cause CI to fail if high-severity vulnerabilities are found, but they won't automatically create GitHub issues that could spam the repository.