### PR TITLE
fix: update repository URLs from code-yeongyu to ANOLASC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Before you begin, ensure you have the following installed:
 
 2. **Set up upstream remote**
    ```bash
-   git remote add upstream https://github.com/code-yeongyu/freqtrade-rs.git
+   git remote add upstream https://github.com/ANOLASC/freqtrade-rs.git
    ```
 
 3. **Install dependencies**
@@ -369,7 +369,7 @@ Links to related documentation.
 
 ### I want to contribute but don't know where to start
 
-Check out the [Good First Issues](https://github.com/code-yeongyu/freqtrade-rs/issues?q=label:good+first+issue) label.
+Check out the [Good First Issues](https://github.com/ANOLASC/freqtrade-rs/issues?q=label:good+first+issue) label.
 
 ### I have a question about the project
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -60,7 +60,7 @@
 
 2. **设置 upstream 远程**
    ```bash
-   git remote add upstream https://github.com/code-yeongyu/freqtrade-rs.git
+   git remote add upstream https://github.com/ANOLASC/freqtrade-rs.git
    ```
 
 3. **安装依赖**
@@ -367,7 +367,7 @@ describe('Trade', () => {
 
 ### 我想贡献但不知道从哪里开始
 
-查看 [Good First Issues](https://github.com/code-yeongyu/freqtrade-rs/issues?q=label:good+first+issue) 标签。
+查看 [Good First Issues](https://github.com/ANOLASC/freqtrade-rs/issues?q=label:good+first+issue) 标签。
 
 ### 关于项目有问题
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,11 +44,11 @@
 
 ```bash
 # Clone with HTTPS
-git clone https://github.com/code-yeongyu/freqtrade-rs.git
+git clone https://github.com/ANOLASC/freqtrade-rs.git
 cd freqtrade-rs
 
 # Or with SSH
-git clone git@github.com:code-yeongyu/freqtrade-rs.git
+git clone git@github.com:ANOLASC/freqtrade-rs.git
 cd freqtrade-rs
 ```
 

--- a/DEVELOPMENT_CN.md
+++ b/DEVELOPMENT_CN.md
@@ -44,11 +44,11 @@
 
 ```bash
 # 使用 HTTPS 克隆
-git clone https://github.com/code-yeongyu/freqtrade-rs.git
+git clone https://github.com/ANOLASC/freqtrade-rs.git
 cd freqtrade-rs
 
 # 或使用 SSH
-git clone git@github.com:code-yeongyu/freqtrade-rs.git
+git clone git@github.com:ANOLASC/freqtrade-rs.git
 cd freqtrade-rs
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ freqtrade-rs/
 ## 🔗 相关资源
 
 - [freqtrade Python](https://github.com/freqtrade/freqtrade) - 原版Python项目
-- [freqtrade-rs GitHub](https://github.com/code-yeongyu/freqtrade-rs) - 本项目仓库
+- [freqtrade-rs GitHub](https://github.com/ANOLASC/freqtrade-rs) - 本项目仓库
 
 ## 🤝 许可证
 

--- a/docs/user-guide/QUICK_START.md
+++ b/docs/user-guide/QUICK_START.md
@@ -220,9 +220,9 @@ pnpm run dev -- --port 3000
 
 | Resource | Link |
 |----------|------|
-| GitHub Issues | [github.com/code-yeongyu/freqtrade-rs/issues](https://github.com/code-yeongyu/freqtrade-rs/issues) |
+| GitHub Issues | [github.com/ANOLASC/freqtrade-rs/issues](https://github.com/ANOLASC/freqtrade-rs/issues) |
 | Discord | [discord.gg/freqtrade](https://discord.gg/p7nuUxk) |
-| Wiki | [github.com/code-yeongyu/freqtrade-rs/wiki](https://github.com/code-yeongyu/freqtrade-rs/wiki) |
+| Wiki | [github.com/ANOLASC/freqtrade-rs/wiki](https://github.com/ANOLASC/freqtrade-rs/wiki) |
 
 ---
 

--- a/docs/user-guide/QUICK_START_CN.md
+++ b/docs/user-guide/QUICK_START_CN.md
@@ -221,9 +221,9 @@ pnpm run dev -- --port 3000
 
 | 资源 | 链接 |
 |----------|------|
-| GitHub Issues | [github.com/code-yeongyu/freqtrade-rs/issues](https://github.com/code-yeongyu/freqtrade-rs/issues) |
+| GitHub Issues | [github.com/ANOLASC/freqtrade-rs/issues](https://github.com/ANOLASC/freqtrade-rs/issues) |
 | Discord | [discord.gg/freqtrade](https://discord.gg/p7nuUxk) |
-| Wiki | [github.com/code-yeongyu/freqtrade-rs/wiki](https://github.com/code-yeongyu/freqtrade-rs/wiki) |
+| Wiki | [github.com/ANOLASC/freqtrade-rs/wiki](https://github.com/ANOLASC/freqtrade-rs/wiki) |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixed all broken GitHub links by updating repository URLs from the old owner (`code-yeongyu`) to the new owner (`ANOLASC`).

## Changes

Updated GitHub repository references in 7 files:

| File | Changes |
|------|---------|
| README.md | Repository link in "Related Resources" section |
| CONTRIBUTING.md | Upstream remote URL, Good First Issues link |
| CONTRIBUTING_CN.md | Same as CONTRIBUTING.md (Chinese version) |
| DEVELOPMENT.md | Clone URLs (HTTPS and SSH) |
| DEVELOPMENT_CN.md | Same as DEVELOPMENT.md (Chinese version) |
| docs/user-guide/QUICK_START.md | Issues and Wiki links in resources table |
| docs/user-guide/QUICK_START_CN.md | Same as QUICK_START.md (Chinese version) |

## Before vs After

```diff
- https://github.com/code-yeongyu/freqtrade-rs
+ https://github.com/ANOLASC/freqtrade-rs
```

All links that were returning 404 are now fixed.